### PR TITLE
Changes to record class member variables. Updated mif-read accordingly.

### DIFF
--- a/pylib/pymex/mif/record.py
+++ b/pylib/pymex/mif/record.py
@@ -76,7 +76,6 @@ class Record():
     def genericParse(self, template, ver, rec, rpath, elem, wrapped=False, debug=False):
         
         tag = self.modifyTag( elem, ver )
-        print(tag)
         #find corresponding template
         if tag in template:
             ttempl = template[tag]

--- a/script/mif-read.py
+++ b/script/mif-read.py
@@ -88,7 +88,7 @@ for cs in source:
         
     if args.ofile == 'STDOUT':
          if args.oformat == 'mif254':
-             print( ET.tostring(rec.toMoMif('test'),pretty_print=True).decode("utf-8") )
+             print( ET.tostring(rec.toMoMif('mif254'),pretty_print=True).decode("utf-8") )
          elif args.oformat == 'mif300':
              print( ET.tostring(rec.toMif('mif300'),pretty_print=True).decode("utf-8") )
          else:


### PR DESCRIPTION
No longer need "test" as an argument for toMoMif, version can be passed in directly. 

modifyTag, genericParse, MoGenericMifGenerator, MoGenericMifElement now take version as an argument.